### PR TITLE
Fixed SSL request issue

### DIFF
--- a/fortigate.py
+++ b/fortigate.py
@@ -157,7 +157,9 @@ INPUT = args.input
 OUTPUTFILE = args.output
 PRINTABLE = set(bytes(string.printable, 'ascii'))
 RESULTS = []
-NOSSL = ssl.SSLContext()
+NOSSL = ssl.create_default_context()
+NOSSL.check_hostname = False
+NOSSL.verify_mode = ssl.CERT_NONE
 LOOKFOR = bytearray([0x5d,0x01])
 LOOKFORTWO = bytearray([0x5c,0x01])
 


### PR DESCRIPTION
Previously, running the script against a host using SSL would error out in the following fashion:

Traceback (most recent call last):
  File "fortigate.py", line 160, in <module>
    NOSSL = ssl.SSLContext()

The added code for the SSL context fixes the issue