### PR TITLE
Added pyOpenSSL to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 IPy
+pyOpenSSL


### PR DESCRIPTION
If installed in a venv, pyOpenSSL needs to be installed.